### PR TITLE
fix(plugins.translations-xml): apply toString if text is a number

### DIFF
--- a/src/plugins/translation-xml.js
+++ b/src/plugins/translation-xml.js
@@ -4,9 +4,11 @@ const parser = require('fast-xml-parser');
 
 const filterText = (text) => {
   if (text) {
-    let filtered = text.replace(/&#13;\n/g, ' '); // carriage returns
-    filtered = filtered.replace(/&#160;/g, ' '); // spaces
-    filtered = filtered.replace(/\{(\s?\d\s?)\}/g, '{{t$1}}'); // {0} => {{t0}}
+    const filtered = text
+      .toString()
+      .replace(/&#13;\n/g, ' ') // carriage returns
+      .replace(/&#160;/g, ' ') // spaces
+      .replace(/\{(\s?\d\s?)\}/g, '{{t$1}}'); // {0} => {{t0}}
     return filtered;
   }
   return text;


### PR DESCRIPTION
Due to [some translations](https://github.com/ovh-ux/ovh-manager-cloud/blob/master/client/app/cloud/project/compute/infrastructure/privateNetwork/dialog/translations/Messages_fr_FR.xml#L25) I have to apply `.toString` method.