### PR TITLE
fix(plugins): use fallback by file

### DIFF
--- a/src/plugins/translation-utils.js
+++ b/src/plugins/translation-utils.js
@@ -27,7 +27,7 @@ const languages = [
 const normalizePath = p => (_.startsWith(p, '.') ? slash(p) : `./${slash(p)}`);
 
 const injectFallbackFunction = (trads, id, subdirectory, format) => {
-  let code = 'let p; switch($translate.fallbackLanguage()) {';
+  let code = 'let p = []; switch($translate.fallbackLanguage()) {';
   languages.forEach((lang) => {
     code += `case '${lang}':`;
     trads.forEach((trad) => {
@@ -35,13 +35,15 @@ const injectFallbackFunction = (trads, id, subdirectory, format) => {
       const fullTradPath = path.resolve(dirname, trad, subdirectory);
       const relativePath = path.relative(dirname, fullTradPath);
       if (fs.existsSync(path.join(fullTradPath, `Messages_${lang}.${format}`))) {
+        code += `if (!path || path === '${normalizePath(relativePath)}') {`;
         const toImport = normalizePath(path.join(relativePath, `Messages_${lang}.${format}`));
-        code += `p = import('${toImport}').then(module => module.default ? module.default : module);`;
+        code += `p.push(import('${toImport}').then(module => module.default ? module.default : module));`;
+        code += '}';
       }
     });
     code += 'break;';
   });
-  code += '} return p;';
+  code += '} return $q.all(p).then((translations) => translations.reduce((previousValue, currentValue) => ({ ...previousValue, ...currentValue }), {})); ';
   return code;
 };
 
@@ -49,38 +51,44 @@ const injectTranslationSwitch = (trads, id, subdirectory, format) => {
   let code = 'switch($translate.use()) {';
 
   languages.forEach((lang) => {
-    let importFound = 0;
     code += `case '${lang}':`;
     trads.forEach((trad) => {
       const dirname = path.dirname(id);
       const fullTradPath = path.resolve(dirname, trad, subdirectory);
       const relativePath = path.relative(dirname, fullTradPath);
-      if (fs.existsSync(path.join(fullTradPath, `Messages_${lang}.${format}`))) {
-        const toImport = normalizePath(path.join(relativePath, `Messages_${lang}.${format}`));
+      const toImport = normalizePath(path.join(relativePath, `Messages_${lang}.${format}`));
 
-        code += `if($translate.use() !== $translate.fallbackLanguage()) {
-          promises.push(
+      const fileExists = fs.existsSync(path.join(fullTradPath, `Messages_${lang}.${format}`));
+
+      code += 'if ($translate.use() !== $translate.fallbackLanguage()) {';
+      if (fileExists) {
+        code += `  promises.push(
             Promise.all([
               import('${toImport}').then(module => module.default ? module.default : module),
-              useFallback(),
+              useFallback('${normalizePath(relativePath)}'),
             ])
             .then(([ translations = {}, fallbackTranslations = {} ]) => {
               return Object.assign(fallbackTranslations, translations);
             })
-          );
-        } else {
+          );`;
+      } else {
+        code += `promises.push(
+              $q.when(
+                useFallback('${normalizePath(relativePath)}'),
+              )
+            );`;
+      }
+      code += '}';
+      if (fileExists) {
+        code += ` else {
           promises.push(
             import('${toImport}').then(module => module.default ? module.default : module),
           );
         }`;
-
-        importFound += 1;
       }
     });
 
-    if (!importFound) {
-      code += 'useFallback();';
-    }
+
     code += 'break;';
   });
   code += 'default: promises.push(useFallback()); break; }';
@@ -89,7 +97,7 @@ const injectTranslationSwitch = (trads, id, subdirectory, format) => {
 
 const injectTranslationImports = (trads, id, subdirectory, format = 'xml') => `
   let promises = [];
-  const useFallback = () => {
+  const useFallback = (path = false) => {
     ${injectFallbackFunction(trads, id, subdirectory, format)}
   };
   ${injectTranslationSwitch(trads, id, subdirectory, format)}


### PR DESCRIPTION
## fix(plugins): use fallback by file

### Description of the Change

Fix useFallback to return translations from multiples files
Call useFallback with path to retrieve fallback for a specific path

2f782a6 — fix(plugins): use fallback by file

ref: 

/cc @jleveugle @frenautvh @antleblanc

